### PR TITLE
hide buttons on mobile

### DIFF
--- a/src-ui/index.css
+++ b/src-ui/index.css
@@ -107,6 +107,12 @@ strong {
   margin-left: 2rem;
 }
 
+@media (max-width: 640px) {
+  .hide-on-mobile {
+    display: none !important;
+  }
+}
+
 /* Cleaner styling for scrollbar */
 ::-webkit-scrollbar {
   width: 5px;

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -4,6 +4,8 @@
 
 /**
  * TODO PRIORITY ORDER
+ *  - auto-save at debounced interval
+ *  - if it's a manual save, display a notification that is removed after a few seconds this will be something new to implement
  *  - add a warning banner for web-only builds that says:
  *      "Running: web version. This is version is for demo purposes only. Please download
  *       the application for the best experience."
@@ -13,8 +15,6 @@
  *    - include the Remix icons apache license AND pouchdb AND tauri in the repo and as a 'legal/about' button (or i icon next to the version number) that renders a dialog in the statusBar
  *      - could include info about the application, its version, its license and the remix icon license
  * - FEATURES
- *   - auto-save at debounced interval
- *   - if it's a manual save, display a notification that is removed after a few seconds this will be something new to implement
  *   - db dialog: showing if connected to local only or remote
  *   - hyperlinks in the editor
  *   - save cursor position to the note object so we can re-open at the correct location

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -4,8 +4,6 @@
 
 /**
  * TODO PRIORITY ORDER
- *  - EDITOR BUTTONS:
- *     - implement bubble menu for font items
  *  - add a warning banner for web-only builds that says:
  *      "Running: web version. This is version is for demo purposes only. Please download
  *       the application for the best experience."

--- a/src-ui/renderer/reactive/editor/editor.ts
+++ b/src-ui/renderer/reactive/editor/editor.ts
@@ -51,18 +51,23 @@ class Editor {
     buttons.forEach((button) => {
       if (isDisabled) button.disabled = true
 
-      // group buttons by data attribute
-      const group = button.dataset.group
-      if (!group) throw new Error('Top menu button is not assigned to a group')
+      const assignButtonToGroup = () => {
+        const group = button.dataset.group
+        if (!group) throw new Error('button is not assigned to a group')
 
-      const groupId = `top-menu-group-${group}`
-      let groupContainer = document.querySelector(`#${groupId}`)
-      if (!groupContainer) {
-        groupContainer = document.createElement('div')
-        groupContainer.id = groupId
+        const groupId = `menu-group-${group}`
+        let groupContainer = document.querySelector(`#${groupId}`)
+        if (!groupContainer) {
+          groupContainer = document.createElement('div')
+          groupContainer.id = groupId
+          if (group === '1') groupContainer.classList.add('hide-on-mobile')
+        }
+
+        container.appendChild(groupContainer)
+        groupContainer.appendChild(button)
       }
-      container.appendChild(groupContainer)
-      groupContainer.appendChild(button)
+
+      assignButtonToGroup()
     })
   }
 


### PR DESCRIPTION
- Attempted to use [Tiptaps Bubble Menu](https://tiptap.dev/docs/editor/api/extensions/bubble-menu), but ran into implementation problems where the menu always disappeared on an inside click. Unable to find any solutions online or through Copilot. Doesn't look like anyone is trying to implement this with vanilla JS (at least through online discourse)
- Because bold, italic, underline, and strike through are not necessary for mobile note-taking, I'm hiding on those options on mobile.