### PR TITLE
fix/editor-menu-ordering

### DIFF
--- a/cypress/e2e/editor.cy.ts
+++ b/cypress/e2e/editor.cy.ts
@@ -44,6 +44,12 @@ describe('editor', () => {
         data.expected.editor.ellipsisToolbarButtonCount.small
       )
 
+    // and the first item is H1, so that we know items were ordered correctly
+    cy.get(locators.editor.menu.ellipsisSection)
+      .children()
+      .eq(0)
+      .should('contain.text', 'Heading 1')
+
     // closing the sidebar renders all the buttons without ellipsis
     cy.get(locators.sidebar.close).click()
     cy.wait(DEFAULT_WAIT)

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -37,7 +37,6 @@
  * - BUGS (which also need e2e tests)
  *    - if a note id is present in the URL, but not in the database, the editor is ACTIVATED!!! It must be disabled
  *    - if unable to find data, need to be able to delete the undefined notes
- *    - when menu item groups are added to the ellipsis, they are backwards: h1, h2, h3 from the main bar become h3, h2, h1 (add e2e around this)
  *
  *  - Add test reports for unit and e2e to readme
  *

--- a/src-ui/renderer/reactive/editor/editor.ts
+++ b/src-ui/renderer/reactive/editor/editor.ts
@@ -310,10 +310,15 @@ class Editor {
           editorWidth < width &&
           lastMainIndex === groupIndex &&
           getLastGroupElements(lastMainIndex).length
-        if (shouldMoveButtonsIntoEllipsis)
-          getLastGroupElements(lastMainIndex).forEach((group) =>
+        if (shouldMoveButtonsIntoEllipsis) {
+          // put the items in the ellipsis menu in the correct order.
+          // Must .reverse() and .prepend() to ensure the order becomes:
+          // H1, H2, H3 in the main menu and consistent in the ellipsis menu
+          const groups = Array.from(getLastGroupElements(lastMainIndex))
+          groups.reverse().forEach((group) => {
             this.editorMenuEllipsisContainer?.prepend(group)
-          )
+          })
+        }
 
         // process ellipsis menu
         const lastIndexInEllipsis = getGroupIndex(


### PR DESCRIPTION
**Overview**
- Fixed ellipsis menu from rendering groups incorrectly. Groups were in the right place but the items in groups were opposite: H3, H2, H1 instead of H1, H2, ...
- Added e2e for this