### PR TITLE
Feature/sidebar styling

### DIFF
--- a/cypress/e2e/editor.cy.ts
+++ b/cypress/e2e/editor.cy.ts
@@ -7,6 +7,15 @@ describe('editor', () => {
     // by default, cypress always clears localStorage between test runs
   })
 
+  it.skip(
+    'TODO - editor is disabled if note not found in database'
+    // create a note
+    // in the URL, go to an ID that does not exist
+    // the editor should have GET STARTED text
+    // the editor should be disabled
+    // an ERROR should be rendered in the status bar
+  )
+
   it('editor menu buttons move to ellipsis menu properly on sidebar resize', () => {
     cy.viewport(1020, 768) // picking non-standard sizes here to test edge case
     cy.visit('/')

--- a/cypress/e2e/sidebar.cy.ts
+++ b/cypress/e2e/sidebar.cy.ts
@@ -20,14 +20,14 @@ describe('sidebar', () => {
     cy.wait(DEFAULT_WAIT)
     cy.get(locators.sidebar.mainElement).should('not.exist')
     cy.get(locators.editor.content).should('be.visible')
-    cy.writeContent('Some content...')
+    cy.writeContent('First note content...')
     cy.get(locators.statusBar.save).click()
 
     // reloading the page renders the note and its content, and no sidebar
     cy.reload()
     cy.wait(DEFAULT_WAIT)
     cy.get(locators.sidebar.mainElement).should('not.exist')
-    cy.validateContent('Some content...')
+    cy.validateContent('First note content...')
 
     // can create a new note and select it
     // open the sidebar from status bar
@@ -199,7 +199,7 @@ describe('sidebar', () => {
     cy.visit('/')
     cy.wait(DEFAULT_WAIT)
     // check the sidebar width is the default
-    cy.get(locators.sidebar.mainElement).should('have.css', 'width', '170px')
+    cy.get(locators.sidebar.mainElement).should('have.css', 'width', '230px')
     // no ellipsis button as the editor is wide
     cy.get(locators.editor.menu.ellipsisButton).should('not.be.visible')
 

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -5,10 +5,17 @@
  *   - right click a note allows you to delete it from the sidebar.
  *   - save cursor position to the note object so we can re-open at the correct location
  *   - add hyperlink insert support
+ *   - Put a MAX CHARACTER COUNT so that the app doesn't crash (tip tap allows this option).
+ *     When it nears the limit show a warning banner and mention the need to split
+ *     into multiple notes. (Also need to test what the max is more. It should be
+ *     anything that begins to make a noticeable slow-down but doesn't crash.)
+ *     You can currently crash the app.
  *   - e2e:
  *    - if it's main branch, use production link (new action?)
  *    - otherwise, build environment and use that (what's currently setup)
  *    - finish remaining test todos
+ *    - re-do structure so that I can get it setup with a Docker Pouch DB instance
+ *      and have the same setup run on local and CI/CD
  *
  * - BRANDING
  *   - make favicon

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -8,6 +8,7 @@
  *   - e2e:
  *    - if it's main branch, use production link (new action?)
  *    - otherwise, build environment and use that (what's currently setup)
+ *    - finish remaining test todos
  *
  * - BRANDING
  *   - make favicon
@@ -269,6 +270,7 @@ window.addEventListener(NoteEvents.Create, async (event) => {
     sidebar.closeInput()
     if (isMobile) sidebar.close()
     createEvent(LifeCycleEvents.QueryParamUpdate, { noteId: _id }).dispatch()
+    createEvent(NoteEvents.GetAll).dispatch()
     logger.log('info', `Note created: ${title}.`)
   } catch (error) {
     logger.log('error', 'Error creating note.', error)

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -1,20 +1,10 @@
 /**
- * TODO PRIORITY ORDER
- *  - Responsiveness
- *    - sidebar buttons need to have their width match the element (using JS)
- *
- *  - DATABASE DIALOG FORM:
- *     - Must have a way to STOP a connection attempt: cancel button in the status section
- *     - Disable the submit button UNTIL all inputs are filled.
- *       Need to disable the submit if the full form hasn't been entered
- *       on CHANGE not just initial. If the form has been changed, updated
- *       the button copy from Reconnect to Connect (as it has changed)
- *     - password input needs to be **** instead of not hidden
+ * TODOs
  *
  * - FEATURES
+ *   - right click a note allows you to delete it from the sidebar.
  *   - save cursor position to the note object so we can re-open at the correct location
  *   - add hyperlink insert support
- *   - right click a note allows you to delete it from the sidebar.
  *   - e2e:
  *    - if it's main branch, use production link (new action?)
  *    - otherwise, build environment and use that (what's currently setup)
@@ -22,8 +12,13 @@
  * - BRANDING
  *   - make favicon
  *
- * - BUGS (which also need e2e tests)
- *    - if a note id is present in the URL, but not in the database, the editor is ACTIVATED!!! It must be disabled
+ * - DATABASE DIALOG FORM:
+ *    - Must have a way to STOP a connection attempt: cancel button in the status section
+ *    - Disable the submit button UNTIL all inputs are filled.
+ *      Need to disable the submit if the full form hasn't been entered
+ *      on CHANGE not just initial. If the form has been changed, updated
+ *      the button copy from Reconnect to Connect (as it has changed)
+ *    - password input needs to be **** instead of not hidden
  *
  * - DATABASE INTERACTIONS
  *     Thoroughly manually test db scenarios:
@@ -109,12 +104,12 @@ window.addEventListener(DatabaseEvents.Init, async () => {
 
   // can only fetch notes after the database has been fully initialized
   const { noteId } = urlController.getParams()
-  noteId
-    ? createEvent(LifeCycleEvents.QueryParamUpdate, {
-        noteId,
-        isDbInit: true,
-      }).dispatch()
-    : createEvent(NoteEvents.GetAll).dispatch()
+  noteId &&
+    createEvent(LifeCycleEvents.QueryParamUpdate, {
+      noteId,
+      isDbInit: true,
+    }).dispatch()
+  createEvent(NoteEvents.GetAll).dispatch()
 })
 
 /**
@@ -160,7 +155,6 @@ window.addEventListener(LifeCycleEvents.QueryParamUpdate, async (event) => {
     if (editor.getIsDirty()) await saveNote()
     urlController.setParam(PARAMS.NOTE_ID, noteId)
     createEvent(NoteEvents.Select, { _id: noteId }).dispatch()
-    createEvent(NoteEvents.GetAll).dispatch()
   }
 
   if (noteId === null) {
@@ -263,8 +257,6 @@ window.addEventListener(NoteEvents.Select, async (event) => {
     statusBar.renderActiveNote(note)
     editor.setNote(note)
     editor.setCursorPosition('start')
-
-    createEvent(NoteEvents.GetAll).dispatch()
   } catch (error) {
     logger.log('error', 'Error selecting note.', error)
   }

--- a/src-ui/renderer/components/button/button.css
+++ b/src-ui/renderer/components/button/button.css
@@ -6,7 +6,7 @@ button {
   border: 0.13rem solid var(--outline-color);
   padding: 0.25rem 0.4rem;
 
-  font-size: medium;
+  font-size: small;
   font-weight: bold;
 
   cursor: pointer;

--- a/src-ui/renderer/reactive/sidebar/sidebar.css
+++ b/src-ui/renderer/reactive/sidebar/sidebar.css
@@ -7,6 +7,7 @@
 .sidebar-main {
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
   /* Width is setup by ResizeObserver */
   width: 170px;
 }
@@ -75,6 +76,11 @@
   justify-content: space-between;
 }
 
+.note-create-button {
+  font-size: small;
+  padding: 0 0.5rem 0 0.25rem;
+}
+
 #sidebar-list {
   overflow-y: auto;
   overflow-x: hidden;
@@ -108,14 +114,22 @@
   text-align: left;
 }
 
-.note-select-container > button > div > div:first-child {
+.note-select-container > button > div {
+  display: flex;
+  flex-direction: column;
+}
+
+.note-select-container > button > div {
+  font-size: medium;
+}
+
+.note-button-text-resize {
   display: inline-block;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  /* TODO: these need to follow with the resized container */
-  /* and need to be a percentage smaller */
-  max-width: 12.5rem;
+  /* this max-width is reset using JS */
+  max-width: 15rem;
 }
 
 .note-select-container > button:hover {

--- a/src-ui/use-local-storage/use-local-storage.spec.ts
+++ b/src-ui/use-local-storage/use-local-storage.spec.ts
@@ -69,12 +69,12 @@ describe('use-local-storage', () => {
   })
 
   it('returns default sidebar width if none given', () => {
-    expect(useLocalStorage.get('sidebar-width')).toEqual({ width: 170 })
+    expect(useLocalStorage.get('sidebar-width')).toEqual({ width: 230 })
   })
 
   it('does not retrieve sidebar width if invalid data is stored', () => {
     localStorageGetSpy.mockReturnValue(JSON.stringify({ width: '910' }))
-    expect(useLocalStorage.get('sidebar-width')).toEqual({ width: 170 })
+    expect(useLocalStorage.get('sidebar-width')).toEqual({ width: 230 })
   })
 
   it('does not set sidebar width if invalid value', () => {

--- a/src-ui/use-local-storage/use-local-storage.ts
+++ b/src-ui/use-local-storage/use-local-storage.ts
@@ -27,7 +27,7 @@ class UseLocalStorage {
       host: '',
       port: '',
     },
-    'sidebar-width': { width: 170 },
+    'sidebar-width': { width: 230 },
   }
 
   public get(key: AllowedKeys) {


### PR DESCRIPTION
**Overview**
- On sidebar first render and resize, set text ellipsis width to less than the main element width to allow for accurate resizing.
- Reduced calls to get all notes to reduce re-renders. These were unnecessary calls as no state actually changed. Notes only re-fetch on Create, Save, and DB Connection. May need a different approach, but not yet