### PR TITLE
 feature/sidebar-note-delete 

### DIFF
--- a/cypress/constants/locators.ts
+++ b/cypress/constants/locators.ts
@@ -3,6 +3,7 @@ export const locators = {
     close: '[testid="dialog-close"]',
     deleteDialog: {
       confirmButton: '[data-testid="delete-forever"]',
+      header: '[testid="delete-dialog-header"]',
     },
     about: {
       agplButton: '[data-testid="view-agpl"]',

--- a/cypress/e2e/editor.cy.ts
+++ b/cypress/e2e/editor.cy.ts
@@ -7,14 +7,33 @@ describe('editor', () => {
     // by default, cypress always clears localStorage between test runs
   })
 
-  it.skip(
-    'TODO - editor is disabled if note not found in database'
-    // create a note
-    // in the URL, go to an ID that does not exist
-    // the editor should have GET STARTED text
-    // the editor should be disabled
-    // an ERROR should be rendered in the status bar
-  )
+  it('editor is disabled if note not found in database', () => {
+    cy.visit('/')
+    cy.wait(DEFAULT_WAIT)
+
+    cy.createNote('test note')
+    cy.wait(DEFAULT_WAIT)
+    cy.writeContent('Here is some content')
+    cy.wait(DEFAULT_WAIT)
+
+    // no errors are in the status bar
+    cy.get(locators.statusBar.alert).should('not.exist')
+    cy.wait(DEFAULT_WAIT)
+
+    // go to a url with a note id that doesn't exist
+    cy.visit('/?noteId=thisNoteDoesNotExist')
+    cy.wait(DEFAULT_WAIT)
+
+    // renders the get started page and the editor is disabled
+
+    cy.validateContent(data.expected.editor.content.default)
+    cy.get(locators.editor.content)
+      .children()
+      .first()
+      .invoke('attr', 'contenteditable')
+      .should('eq', 'false')
+    cy.get(locators.statusBar.alert).should('exist')
+  })
 
   it('editor menu buttons move to ellipsis menu properly on sidebar resize', () => {
     cy.viewport(1020, 768) // picking non-standard sizes here to test edge case

--- a/cypress/e2e/sidebar.cy.ts
+++ b/cypress/e2e/sidebar.cy.ts
@@ -7,7 +7,7 @@ describe('sidebar', () => {
     // by default, cypress always clears localStorage between test runs
   })
 
-  it.skip('handles creating and selecting a note on small screen sizes', () => {
+  it('handles creating and selecting a note on small screen sizes', () => {
     cy.viewport(dimensions.small.viewPortWidth, dimensions.small.viewPortHeight)
     cy.visit('/')
 
@@ -45,7 +45,7 @@ describe('sidebar', () => {
     cy.validateContent('Second note content...')
   })
 
-  it.skip('handles resizing the viewport with the sidebar open', () => {
+  it('handles resizing the viewport with the sidebar open', () => {
     // starting on large screen sizes
     cy.viewport(dimensions.large.viewPortWidth, dimensions.large.viewPortHeight)
     cy.visit('/')
@@ -77,7 +77,7 @@ describe('sidebar', () => {
     cy.get(locators.editor.content).should('be.visible')
   })
 
-  it.skip('handles resizing the viewport with the sidebar closed', () => {
+  it('handles resizing the viewport with the sidebar closed', () => {
     // starting on large screen sizes
     cy.viewport(dimensions.large.viewPortWidth, dimensions.large.viewPortHeight)
     cy.visit('/')
@@ -109,7 +109,7 @@ describe('sidebar', () => {
     cy.get(locators.editor.content).should('be.visible')
   })
 
-  it.skip('handles creating a note on larger screen sizes', () => {
+  it('handles creating a note on larger screen sizes', () => {
     cy.visit('/')
     // tests all scenarios on note creating
 
@@ -255,18 +255,56 @@ describe('sidebar', () => {
     cy.get(locators.editor.content).should('not.be.visible')
   })
 
-  it.skip(
-    'on small screen size, allows for deleting notes by long-press'
-    // on small size
-    // create a few notes
-    // right click on a non-selected note, and delete it
-    // SIDEBAR SHOULD STAY RENDERED!
-    // refreshing the page keeps the sidebar open
-    //
-    // pressing on a note that is already selected still allows for deleting
-  )
+  it('on small screen size, allows for deleting notes by long-press', () => {
+    cy.viewport(dimensions.small.viewPortWidth, dimensions.small.viewPortHeight)
+    cy.visit('/')
 
-  it.skip('tracks sidebar open/closed state across page reloads', () => {
+    // create a few notes
+    cy.createNote('My first note')
+    cy.wait(DEFAULT_WAIT)
+    cy.writeContent('First note content...')
+    cy.wait(DEFAULT_WAIT)
+    cy.get(locators.statusBar.sidebarToggle).click()
+    cy.createNote('My second note')
+    cy.wait(DEFAULT_WAIT)
+    cy.writeContent('Second note content...')
+    cy.wait(DEFAULT_WAIT)
+    cy.get(locators.statusBar.sidebarToggle).click()
+    cy.createNote('My third note')
+    cy.wait(DEFAULT_WAIT)
+    cy.writeContent('Third note content...')
+    cy.wait(DEFAULT_WAIT)
+    cy.get(locators.statusBar.sidebarToggle).click()
+    cy.wait(DEFAULT_WAIT)
+
+    // simulate a long press tap
+    cy.get(locators.sidebar.note)
+      .eq(2)
+      .trigger('touchstart', { which: 1 })
+      .wait(1000)
+      .trigger('touchend', { force: true })
+    cy.wait(DEFAULT_WAIT)
+
+    cy.get(locators.dialog.deleteDialog.header).should(
+      'be.contain',
+      'My first note'
+    )
+    cy.get(locators.dialog.deleteDialog.confirmButton).click()
+    cy.wait(DEFAULT_WAIT)
+
+    // only the second and third notes are left
+    cy.get(locators.sidebar.note).should('have.length', 2)
+    cy.get(locators.sidebar.note).eq(0).should('be.contain', 'My third note')
+    cy.get(locators.sidebar.note).eq(1).should('be.contain', 'My second note')
+
+    // refreshing the page keeps the sidebar open
+    cy.reload()
+    cy.wait(DEFAULT_WAIT)
+    cy.get(locators.sidebar.mainElement).should('be.visible')
+    cy.get(locators.sidebar.note).should('have.length', 2)
+  })
+
+  it('tracks sidebar open/closed state across page reloads', () => {
     cy.visit('/')
     // default sidebar value added
     cy.location('search').should('eq', '?sidebar=open')
@@ -302,7 +340,7 @@ describe('sidebar', () => {
     cy.get(locators.sidebar.createNote.button).should('not.exist')
   })
 
-  it.skip('resizing the sidebar saves it to local storage', () => {
+  it('resizing the sidebar saves it to local storage', () => {
     cy.clearLocalStorage()
     cy.visit('/')
     cy.wait(DEFAULT_WAIT)

--- a/cypress/e2e/sidebar.cy.ts
+++ b/cypress/e2e/sidebar.cy.ts
@@ -1,4 +1,4 @@
-import { locators, DEFAULT_WAIT, dimensions } from '../constants'
+import { locators, DEFAULT_WAIT, dimensions, data } from '../constants'
 import { clearIndexDb } from '../utils'
 
 describe('sidebar', () => {
@@ -7,7 +7,7 @@ describe('sidebar', () => {
     // by default, cypress always clears localStorage between test runs
   })
 
-  it('handles creating and selecting a note on small screen sizes', () => {
+  it.skip('handles creating and selecting a note on small screen sizes', () => {
     cy.viewport(dimensions.small.viewPortWidth, dimensions.small.viewPortHeight)
     cy.visit('/')
 
@@ -45,7 +45,7 @@ describe('sidebar', () => {
     cy.validateContent('Second note content...')
   })
 
-  it('handles resizing the viewport with the sidebar open', () => {
+  it.skip('handles resizing the viewport with the sidebar open', () => {
     // starting on large screen sizes
     cy.viewport(dimensions.large.viewPortWidth, dimensions.large.viewPortHeight)
     cy.visit('/')
@@ -77,7 +77,7 @@ describe('sidebar', () => {
     cy.get(locators.editor.content).should('be.visible')
   })
 
-  it('handles resizing the viewport with the sidebar closed', () => {
+  it.skip('handles resizing the viewport with the sidebar closed', () => {
     // starting on large screen sizes
     cy.viewport(dimensions.large.viewPortWidth, dimensions.large.viewPortHeight)
     cy.visit('/')
@@ -109,7 +109,7 @@ describe('sidebar', () => {
     cy.get(locators.editor.content).should('be.visible')
   })
 
-  it('handles creating a note on larger screen sizes', () => {
+  it.skip('handles creating a note on larger screen sizes', () => {
     cy.visit('/')
     // tests all scenarios on note creating
 
@@ -158,22 +158,102 @@ describe('sidebar', () => {
     cy.get(locators.sidebar.mainElement).should('be.visible')
   })
 
-  it.skip(
-    'handles deleting a note on different screen sizes by right click'
-    // large size
-    // create a few notes + content for easier validation
-    // check to see which ones is selected and rendered
-    // right click on a non-selected note, and delete it
-    // the previously selected note should stay rendered (IF THAT IS EASY TO IMPLEMENT)
-    //
-    // clicking a note that is already selected still allows for deleting
-    //
-    // on small size
-    // create a few notes
-    // right click on a non-selected note, and delete it
-    // SIDEBAR SHOULD STAY RENDERED!
-    // refreshing the page keeps the sidebar open
-  )
+  it('handles deleting a note on different screen sizes by right click', () => {
+    cy.viewport(dimensions.large.viewPortWidth, dimensions.large.viewPortHeight)
+    cy.visit('/')
+
+    cy.createNote('My first note')
+    cy.wait(DEFAULT_WAIT)
+    cy.writeContent('First note content...')
+    cy.wait(DEFAULT_WAIT)
+    cy.createNote('My second note')
+    cy.wait(DEFAULT_WAIT)
+    cy.writeContent('Second note content...')
+    cy.wait(DEFAULT_WAIT)
+    cy.createNote('My third note')
+    cy.wait(DEFAULT_WAIT)
+    cy.writeContent('Third note content...')
+    cy.wait(DEFAULT_WAIT)
+
+    // by this point the third note is rendered
+    // right clicking on the first note opens the delete dialog with the note title rendered
+    cy.get(locators.sidebar.note).eq(2).rightclick()
+    cy.get(locators.dialog.deleteDialog.header).should(
+      'be.contain',
+      'My first note'
+    )
+    // delete the note
+    cy.get(locators.dialog.deleteDialog.confirmButton).click()
+    cy.wait(DEFAULT_WAIT)
+    // render the getting started section as there is no data
+    cy.validateContent(data.expected.editor.content.default)
+
+    // user can't edit the get started text
+    cy.get(locators.editor.content)
+      .children()
+      .first()
+      .invoke('attr', 'contenteditable')
+      .should('eq', 'false')
+
+    // select the third note
+    cy.get(locators.sidebar.note).eq(0).click()
+    cy.validateContent('Third note content...')
+
+    // right click the third note and delete it
+    cy.get(locators.sidebar.note).eq(0).rightclick()
+    cy.get(locators.dialog.deleteDialog.header).should(
+      'be.contain',
+      'My third note'
+    )
+    cy.get(locators.dialog.deleteDialog.confirmButton).click()
+    cy.wait(DEFAULT_WAIT)
+
+    // only the second note is left
+    cy.get(locators.sidebar.note).should('have.length', 1)
+    cy.get(locators.sidebar.note).eq(0).should('be.contain', 'My second note')
+
+    // resize to a smaller screen size
+    cy.viewport(dimensions.small.viewPortWidth, dimensions.small.viewPortHeight)
+    cy.wait(DEFAULT_WAIT)
+    // create the first and third notes again
+    cy.createNote('My first note')
+    cy.wait(DEFAULT_WAIT)
+    cy.writeContent('First note content...')
+    cy.wait(DEFAULT_WAIT)
+    // open sidebar
+    cy.get(locators.statusBar.sidebarToggle).click()
+    cy.createNote('My third note')
+    cy.wait(DEFAULT_WAIT)
+    cy.writeContent('Third note content...')
+    cy.wait(DEFAULT_WAIT)
+
+    // open sidebar
+    cy.get(locators.statusBar.sidebarToggle).click()
+
+    // right click opens the dialog
+    cy.get(locators.sidebar.note).eq(1).rightclick()
+    cy.get(locators.dialog.deleteDialog.header).should(
+      'be.contain',
+      'My first note'
+    )
+    // delete the note
+    cy.get(locators.dialog.deleteDialog.confirmButton).click()
+    cy.wait(DEFAULT_WAIT)
+
+    // the delete dialog is no longer rendered
+    cy.get(locators.dialog.deleteDialog.header).should('not.exist')
+
+    // sidebar is still opened with only the two remaining notes
+    cy.get(locators.sidebar.note).should('have.length', 2)
+    cy.get(locators.sidebar.note).eq(0).should('be.contain', 'My third note')
+    cy.get(locators.sidebar.note).eq(1).should('be.contain', 'My second note')
+
+    // refreshing the page keeps the sidebar opened because no note is selected
+    cy.reload()
+    cy.wait(DEFAULT_WAIT)
+    cy.get(locators.sidebar.mainElement).should('be.visible')
+    cy.get(locators.editor.content).should('not.be.visible')
+  })
 
   it.skip(
     'on small screen size, allows for deleting notes by long-press'
@@ -186,7 +266,7 @@ describe('sidebar', () => {
     // pressing on a note that is already selected still allows for deleting
   )
 
-  it('tracks sidebar open/closed state across page reloads', () => {
+  it.skip('tracks sidebar open/closed state across page reloads', () => {
     cy.visit('/')
     // default sidebar value added
     cy.location('search').should('eq', '?sidebar=open')
@@ -222,7 +302,7 @@ describe('sidebar', () => {
     cy.get(locators.sidebar.createNote.button).should('not.exist')
   })
 
-  it('resizing the sidebar saves it to local storage', () => {
+  it.skip('resizing the sidebar saves it to local storage', () => {
     cy.clearLocalStorage()
     cy.visit('/')
     cy.wait(DEFAULT_WAIT)

--- a/cypress/e2e/sidebar.cy.ts
+++ b/cypress/e2e/sidebar.cy.ts
@@ -158,6 +158,34 @@ describe('sidebar', () => {
     cy.get(locators.sidebar.mainElement).should('be.visible')
   })
 
+  it.skip(
+    'handles deleting a note on different screen sizes by right click'
+    // large size
+    // create a few notes + content for easier validation
+    // check to see which ones is selected and rendered
+    // right click on a non-selected note, and delete it
+    // the previously selected note should stay rendered (IF THAT IS EASY TO IMPLEMENT)
+    //
+    // clicking a note that is already selected still allows for deleting
+    //
+    // on small size
+    // create a few notes
+    // right click on a non-selected note, and delete it
+    // SIDEBAR SHOULD STAY RENDERED!
+    // refreshing the page keeps the sidebar open
+  )
+
+  it.skip(
+    'on small screen size, allows for deleting notes by long-press'
+    // on small size
+    // create a few notes
+    // right click on a non-selected note, and delete it
+    // SIDEBAR SHOULD STAY RENDERED!
+    // refreshing the page keeps the sidebar open
+    //
+    // pressing on a note that is already selected still allows for deleting
+  )
+
   it('tracks sidebar open/closed state across page reloads', () => {
     cy.visit('/')
     // default sidebar value added

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -3,7 +3,6 @@
  *
  * v0.0.1
  * FEATURES
- *   - right click a note allows you to delete it from the sidebar without selecting the note.
  *   - save cursor position to local storage so that we can set cursor when the note is re-opened
  *   - add hyperlink insert support
  *   - e2e:

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -4,7 +4,7 @@
  * v0.0.1
  * FEATURES
  *   - right click a note allows you to delete it from the sidebar without selecting the note.
- *   - save cursor position to the note object so we can re-open at the correct location
+ *   - save cursor position to local storage so that we can set cursor when the note is re-opened
  *   - add hyperlink insert support
  *   - e2e:
  *    - finish remaining test todos

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -13,6 +13,9 @@
  * FEATURES
  * - Tauri v2 at least desktop support + Android if it works well
  *
+ * - Right clicking/long-press on a sidebar note opens a context menu instead
+ *   of immediately opening the delete dialog
+ *
  * - Put a MAX CHARACTER COUNT so that the app doesn't crash (tip tap allows this option).
  *     When it nears the limit show a warning banner and mention the need to split
  *     into multiple notes. (Also need to test what the max is more. It should be
@@ -26,6 +29,17 @@
  *      on CHANGE not just initial. If the form has been changed, updated
  *      the button copy from Reconnect to Connect (as it has changed)
  *    - Must have a way to STOP a connection attempt: cancel button in the status section
+ *
+ * - Organization features for notes in sidebar
+ *    Easy adds
+ *    - search bar? (an easy add)
+ *    - a less "busy" sidebar (ie, no dates on when the note was last edited or created,
+ *     or have that toggle-able)
+ *
+ *    More work
+ *    - tags?
+ *    - drag-and-drop re-ordering?
+ *    - "folder" structure?
  *
  * BRANDING
  * - make favicon
@@ -137,6 +151,13 @@ window.addEventListener(LifeCycleEvents.QueryParamUpdate, async (event) => {
   const noteId: string = (event as CustomEvent)?.detail?.noteId
   const dialog: string = (event as CustomEvent)?.detail?.dialog
   const sidebarParam: string = (event as CustomEvent)?.detail?.sidebar
+
+  // for handling the deleting of a note from the sidebar
+  if (dialog === DIALOGS.DELETE && noteId) {
+    const note = await database.getById(noteId)
+    if (note) noteDeleteDialog.render(note)
+    return
+  }
 
   if (sidebarParam) {
     const openSidebar = () => {

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -5,8 +5,6 @@
  * FEATURES
  *   - save cursor position to local storage so that we can set cursor when the note is re-opened
  *   - add hyperlink insert support
- *   - e2e:
- *    - finish remaining test todos
  *
  * v1.0.0
  * FEATURES

--- a/src-ui/renderer/reactive/note-delete-dialog/note-delete-dialog.css
+++ b/src-ui/renderer/reactive/note-delete-dialog/note-delete-dialog.css
@@ -4,3 +4,12 @@
   width: 100vw;
   max-width: 17rem;
 }
+
+.delete-dialog-note-title {
+  display: inline-block;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  /* needs to be a little less than the container */
+  max-width: 16rem;
+}

--- a/src-ui/renderer/reactive/note-delete-dialog/note-delete-dialog.spec.ts
+++ b/src-ui/renderer/reactive/note-delete-dialog/note-delete-dialog.spec.ts
@@ -23,6 +23,7 @@ describe('NoteDeleteDialog', () => {
     await userEvent.click(
       getByRole('button', { name: 'Delete Delete forever' })
     )
+    expect(getByRole('dialog').innerHTML).toContain(note.title)
     expect(createEvent).toHaveBeenCalledWith(NoteEvents.Delete, { note })
   })
 })

--- a/src-ui/renderer/reactive/note-delete-dialog/note-delete-dialog.ts
+++ b/src-ui/renderer/reactive/note-delete-dialog/note-delete-dialog.ts
@@ -16,7 +16,7 @@ class NoteDeleteDialog {
     // TODO: add the ellipsis for SUPER long titles
     dialogContent.innerHTML = `
       <div class='note-delete-container'>
-        <h3>Are you sure you want to delete ${note.title}?</h3>
+        <h3 testid='delete-dialog-header'>Are you sure you want to delete ${note.title}?</h3>
         <p>This action cannot be undone.</p>
       </div>`
 

--- a/src-ui/renderer/reactive/note-delete-dialog/note-delete-dialog.ts
+++ b/src-ui/renderer/reactive/note-delete-dialog/note-delete-dialog.ts
@@ -13,10 +13,10 @@ class NoteDeleteDialog {
     if (this.dialog) this.close()
     this.note = note
     const dialogContent = document.createElement('div')
-    // TODO: add the ellipsis for SUPER long titles
+
     dialogContent.innerHTML = `
       <div class='note-delete-container'>
-        <h3 testid='delete-dialog-header'>Are you sure you want to delete ${note.title}?</h3>
+        <h3 testid='delete-dialog-header'>Are you sure you want to delete <span class='delete-dialog-note-title'>${note.title}?</span></h3>
         <p>This action cannot be undone.</p>
       </div>`
 

--- a/src-ui/renderer/reactive/note-delete-dialog/note-delete-dialog.ts
+++ b/src-ui/renderer/reactive/note-delete-dialog/note-delete-dialog.ts
@@ -13,10 +13,10 @@ class NoteDeleteDialog {
     if (this.dialog) this.close()
     this.note = note
     const dialogContent = document.createElement('div')
-
+    // TODO: add the ellipsis for SUPER long titles
     dialogContent.innerHTML = `
       <div class='note-delete-container'>
-        <h3>Are you sure you want to delete this note?</h3>
+        <h3>Are you sure you want to delete ${note.title}?</h3>
         <p>This action cannot be undone.</p>
       </div>`
 

--- a/src-ui/renderer/reactive/sidebar/sidebar.ts
+++ b/src-ui/renderer/reactive/sidebar/sidebar.ts
@@ -151,11 +151,6 @@ class Sidebar {
         }).getElement()
     )
 
-    // TODO:
-    // before we re-render or call any re-render functions
-    // we need to have a "removeAllListeners" function
-    // to cleanup all of these
-    // and then re-add them once things render
     const contextMenuHandler = (id: string, event: Event) => {
       event.preventDefault()
       createEvent(LifeCycleEvents.QueryParamUpdate, {
@@ -169,6 +164,9 @@ class Sidebar {
       const buttonContainer = document.createElement('div')
       buttonContainer.classList.add('note-select-container')
       buttonContainer.id = `${b.id}-${'note-select-container'}`
+
+      // Not explicitly cleaning up these listeners. If it becomes an issue
+      // write a cleanup function
 
       // apply listeners for context menu and touchscreen long-press
       buttonContainer.addEventListener('contextmenu', (event) =>

--- a/src-ui/renderer/reactive/sidebar/sidebar.ts
+++ b/src-ui/renderer/reactive/sidebar/sidebar.ts
@@ -1,3 +1,4 @@
+import { DIALOGS } from 'const'
 import { LifeCycleEvents, NoteEvents, createEvent } from 'event'
 import { Button, Input } from 'components'
 import { addNoteIcon, closeIcon } from 'icons'
@@ -150,11 +151,43 @@ class Sidebar {
         }).getElement()
     )
 
+    // TODO:
+    // before we re-render or call any re-render functions
+    // we need to have a "removeAllListeners" function
+    // to cleanup all of these
+    // and then re-add them once things render
+    const contextMenuHandler = (id: string, event: Event) => {
+      event.preventDefault()
+      createEvent(LifeCycleEvents.QueryParamUpdate, {
+        dialog: DIALOGS.DELETE,
+        noteId: id,
+      })?.dispatch()
+    }
+
     noteButtons?.forEach((b) => {
       // setup container for button and append to sidebar
       const buttonContainer = document.createElement('div')
       buttonContainer.classList.add('note-select-container')
       buttonContainer.id = `${b.id}-${'note-select-container'}`
+
+      // apply listeners for context menu and touchscreen long-press
+      buttonContainer.addEventListener('contextmenu', (event) =>
+        contextMenuHandler(b.id, event)
+      )
+
+      // Handle long press for mobile
+      let pressTimer: NodeJS.Timeout
+      buttonContainer.addEventListener('touchstart', (event) => {
+        // TODO: will need to test this once it's live (also test with cypress)
+        pressTimer = setTimeout(() => contextMenuHandler(b.id, event), 500)
+      })
+      buttonContainer.addEventListener('touchend', () => {
+        clearTimeout(pressTimer)
+      })
+      buttonContainer.addEventListener('touchmove', () => {
+        clearTimeout(pressTimer)
+      })
+
       buttonContainer.appendChild(b)
       container.appendChild(buttonContainer)
     })

--- a/src-ui/renderer/reactive/sidebar/sidebar.ts
+++ b/src-ui/renderer/reactive/sidebar/sidebar.ts
@@ -175,11 +175,10 @@ class Sidebar {
         contextMenuHandler(b.id, event)
       )
 
-      // Handle long press for mobile
+      // Handle long press for touchscreens
       let pressTimer: NodeJS.Timeout
       buttonContainer.addEventListener('touchstart', (event) => {
-        // TODO: will need to test this once it's live (also test with cypress)
-        pressTimer = setTimeout(() => contextMenuHandler(b.id, event), 500)
+        pressTimer = setTimeout(() => contextMenuHandler(b.id, event), 700)
       })
       buttonContainer.addEventListener('touchend', () => {
         clearTimeout(pressTimer)


### PR DESCRIPTION
**Overview**
- Right click or long-press on sidebar opens delete dialog. No pop-out menu to make this as fast as possible to implement to resolve issues with notes that are no longer of a valid data structure. This is a "hidden" feature.
- added e2e for right click and touch
- Updated styling in delete dialog for long titles