### PR TITLE
Feature/save cursor

### DIFF
--- a/.env.desktop
+++ b/.env.desktop
@@ -1,2 +1,3 @@
 VITE_DATABASE_NAME=notes
 VITE_BASE_URL=/
+VITE_MODE=desktop

--- a/.env.web
+++ b/.env.web
@@ -1,2 +1,3 @@
 VITE_DATABASE_NAME=notes
 VITE_BASE_URL=/notes
+VITE_MODE=web

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ flowchart LR
   A <-- Sync changes --> B
 ```
 
+# Known issues (published web release only)
+
+Cloud syncing is not easy to support for the published web release on `github.io`. This is because github is hosted over `HTTPS`, but the docker container is setup to run on a device on your local LAN which will not have a certified SSL certificate for `HTTPS`. You can connect through the browser, but it requires manually going to the address for your container and forcing the browser to allow the connection. This issue does not exist for the desktop apps because those are not hosted over `HTTPS` but run on your device locally.
+
 # For development
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Once Tauri v2 releases, Notes will support:
 - Keyboard shortcuts
 - Linux, Mac, Windows, and Android
 
+### Known issue (web only)
+
+Will be revisited once Tauri v2 is done. Cloud syncing may be removed from the browser builds to due `HTTPS` and `HTTP` limitations.
+
+Cloud syncing is not easy to support for the published web release on `github.io`. This is because github is hosted over `HTTPS`, but the docker container is setup to run on a device on your LAN that will not have a certified SSL certificate. You can connect through the browser, but it requires manually visiting the address for your container and forcing the browser to allow the connection. This issue does not exist for the desktop apps because those are not hosted over `HTTPS`.
+
 ## Application Architecture
 
 ### Goal
@@ -49,10 +55,6 @@ flowchart LR
     end
   A <-- Sync changes --> B
 ```
-
-# Known issues (published web release only)
-
-Cloud syncing is not easy to support for the published web release on `github.io`. This is because github is hosted over `HTTPS`, but the docker container is setup to run on a device on your local LAN which will not have a certified SSL certificate for `HTTPS`. You can connect through the browser, but it requires manually going to the address for your container and forcing the browser to allow the connection. This issue does not exist for the desktop apps because those are not hosted over `HTTPS` but run on your device locally.
 
 # For development
 

--- a/cypress/e2e/editor.cy.ts
+++ b/cypress/e2e/editor.cy.ts
@@ -184,13 +184,4 @@ describe('editor', () => {
     cy.wait(DEFAULT_WAIT)
     cy.validateContent('Here is some unsaved content')
   })
-
-  it.skip(
-    'saves and restores cursor position'
-    // TODO: see if cypress can test where exactly the cursor is
-    //
-    // create two notes
-    // write content in both
-    // select the first note again, and the cursor should be at the end
-  )
 })

--- a/cypress/e2e/editor.cy.ts
+++ b/cypress/e2e/editor.cy.ts
@@ -184,4 +184,13 @@ describe('editor', () => {
     cy.wait(DEFAULT_WAIT)
     cy.validateContent('Here is some unsaved content')
   })
+
+  it.skip(
+    'saves and restores cursor position'
+    // TODO: see if cypress can test where exactly the cursor is
+    //
+    // create two notes
+    // write content in both
+    // select the first note again, and the cursor should be at the end
+  )
 })

--- a/cypress/e2e/flow.cy.ts
+++ b/cypress/e2e/flow.cy.ts
@@ -188,9 +188,9 @@ describe('flow', () => {
     cy.get(locators.statusBar.save).should('be.enabled')
     cy.get(locators.statusBar.delete).should('be.enabled')
     cy.get(locators.statusBar.savedOn).should('be.visible')
-    // and the editor is still active
-    cy.writeContent('More content! ')
-    cy.validateContent('More content! Lets add some content! Extra.')
+    // and the editor is still active, and the cursor position was saved
+    cy.writeContent(' More content!')
+    cy.validateContent('Lets add some content! Extra. More content!')
     cy.wait(DEFAULT_WAIT)
 
     // can delete first note and the app is reset to the get started screen

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 tauri-build = { version = "1.3", features = [] }
 
 [dependencies]
-tauri = { version = "1.3", features = [ "path-all", "fs-all", "shell-open"] }
+tauri = { version = "1.3", features = [ "shell-open"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,13 +13,6 @@
   "tauri": {
     "allowlist": {
       "all": false,
-      "fs": {
-        "all": true,
-        "scope": ["$APPDATA/*", "$APPDATA/notes/*"]
-      },
-      "path": {
-        "all": true
-      },
       "shell": {
         "all": false,
         "open": true

--- a/src-ui/config.ts
+++ b/src-ui/config.ts
@@ -1,6 +1,7 @@
 const config = {
-  DATABASE_NAME: import.meta.env.VITE_DATABASE_NAME ?? '',
   BASE_URL: import.meta.env.VITE_BASE_URL ?? '/',
+  DATABASE_NAME: import.meta.env.VITE_DATABASE_NAME ?? '',
+  MODE: import.meta.env.VITE_MODE ?? 'web',
 }
 
 export { config }

--- a/src-ui/database/database.ts
+++ b/src-ui/database/database.ts
@@ -158,10 +158,8 @@ class Database {
   private createRemoteUrl() {
     const { username, password, host, port } =
       useLocalStorage.get('remote-db-details')
-    // TODO: if this is a tauri build, use `http`
-    // if it is a browser build, use `https`
     return username && password && host && port
-      ? `https://${username}:${password}@${host}:${port}`
+      ? `http${config.MODE === 'web' ? 's' : ''}://${username}:${password}@${host}:${port}`
       : null
   }
 

--- a/src-ui/database/database.ts
+++ b/src-ui/database/database.ts
@@ -158,6 +158,8 @@ class Database {
   private createRemoteUrl() {
     const { username, password, host, port } =
       useLocalStorage.get('remote-db-details')
+    // TODO: if this is a tauri build, use `http`
+    // if it is a browser build, use `https`
     return username && password && host && port
       ? `https://${username}:${password}@${host}:${port}`
       : null

--- a/src-ui/event/enums.ts
+++ b/src-ui/event/enums.ts
@@ -8,20 +8,17 @@ export enum DatabaseEvents {
   Disconnect = 'remote-disconnect',
 }
 
-export enum DialogEvents {
-  Opened = 'opened-dialog',
-}
-
 export enum KeyboardEvents {
   Keydown = 'keydown',
 }
 
 export enum LifeCycleEvents {
   Init = 'init',
-  WidthChanged = 'width-changed',
-  ShowSaveNotification = 'show-save-notification',
   NoNoteSelected = 'no-note-selected',
+  OpenedDialog = 'opened-dialog',
   QueryParamUpdate = 'query-param-update',
+  ShowSaveNotification = 'show-save-notification',
+  WidthChanged = 'width-changed',
 }
 
 export enum LoggerEvents {
@@ -29,10 +26,11 @@ export enum LoggerEvents {
 }
 
 export enum NoteEvents {
-  GetAll = 'get-all-notes',
-  Select = 'select-note',
   Create = 'create-note',
-  Save = 'save-note',
-  UpdateTitle = 'update-note-title',
   Delete = 'delete-note',
+  GetAll = 'get-all-notes',
+  Save = 'save-note',
+  SaveCursorPosition = 'save-cursor-position',
+  Select = 'select-note',
+  UpdateTitle = 'update-note-title',
 }

--- a/src-ui/event/index.ts
+++ b/src-ui/event/index.ts
@@ -1,9 +1,8 @@
 export { createEvent } from './create-event'
 export {
-  LifeCycleEvents,
-  KeyboardEvents,
-  LoggerEvents,
-  DialogEvents,
   DatabaseEvents,
+  KeyboardEvents,
+  LifeCycleEvents,
+  LoggerEvents,
   NoteEvents,
 } from './enums'

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -62,7 +62,6 @@ import {
   LifeCycleEvents,
   KeyboardEvents,
   LoggerEvents,
-  DialogEvents,
   DatabaseEvents,
   NoteEvents,
   createEvent,
@@ -319,12 +318,17 @@ window.addEventListener(NoteEvents.Save, async (event) => {
     const shouldShowNotification = detail?.shouldShowNotification
     const { updatedAt } = await saveNote()
     statusBar.renderSavedOn(new Date(updatedAt ?? '').toLocaleString())
+    createEvent(NoteEvents.SaveCursorPosition).dispatch()
     createEvent(NoteEvents.GetAll).dispatch() // updates rest of state
     if (shouldShowNotification)
       createEvent(LifeCycleEvents.ShowSaveNotification).dispatch()
   } catch (error) {
     logger.log('error', 'Error saving note.', error)
   }
+})
+
+window.addEventListener(NoteEvents.SaveCursorPosition, () => {
+  editor.saveCursorPosition()
 })
 
 window.addEventListener(NoteEvents.UpdateTitle, async (event) => {
@@ -424,7 +428,7 @@ window.addEventListener(DatabaseEvents.SyncingPaused, (event) => {
  * any dialogs and for rendering specific dialogs.
  *
  */
-window.addEventListener(DialogEvents.Opened, (event) => {
+window.addEventListener(LifeCycleEvents.OpenedDialog, (event) => {
   const focusDialog = () => {
     // because there is not a singleton dialog, find first for now.
     // The dialog component supports 'n' amount, but the app only uses one at a time

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -294,7 +294,6 @@ window.addEventListener(NoteEvents.Select, async (event) => {
 
     statusBar.renderActiveNote(note)
     editor.setNote(note)
-    editor.setCursorPosition('start')
   } catch (error) {
     logger.log('error', 'Error selecting note.', error)
   }

--- a/src-ui/index.ts
+++ b/src-ui/index.ts
@@ -2,8 +2,8 @@
  * TODOs
  *
  * v0.0.1
- * FEATURES
- *   - save cursor position to local storage or db so that we can set cursor when the note is re-opened
+ * - Update readme with image of the app
+ * - set package version to 0.0.1
  *
  * v1.0.0
  * FEATURES

--- a/src-ui/renderer/components/dialog/dialog.ts
+++ b/src-ui/renderer/components/dialog/dialog.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid'
-import { DialogEvents, LifeCycleEvents, createEvent } from 'event'
+import { LifeCycleEvents, createEvent } from 'event'
 import { closeIcon } from 'icons'
 import { trapFocus } from './trap-focus'
 import type { DIALOGS } from 'const'
@@ -93,7 +93,9 @@ class Dialog {
     this.dialog.addEventListener('keydown', this.trapFocusListener)
     this.dialog.addEventListener('keydown', this.escapePressListener)
 
-    createEvent(DialogEvents.Opened, { dialog: this.queryParam })?.dispatch()
+    createEvent(LifeCycleEvents.OpenedDialog, {
+      dialog: this.queryParam,
+    })?.dispatch()
   }
 
   public close() {

--- a/src-ui/renderer/reactive/editor/editor.css
+++ b/src-ui/renderer/reactive/editor/editor.css
@@ -53,7 +53,7 @@
   }
 }
 
-@media (max-width: 580px) {
+@media (max-width: 640px) {
   .editor-title,
   .editor-title-disabled {
     max-width: 35vw;

--- a/src-ui/renderer/reactive/editor/editor.spec.ts
+++ b/src-ui/renderer/reactive/editor/editor.spec.ts
@@ -36,7 +36,7 @@ describe('editor', () => {
     expect(getByRole('button', { name: 'Note title' })).toHaveTextContent(
       note.title
     )
-    expect(createEvent).not.toHaveBeenCalled()
+    expect(createEvent).not.toHaveBeenCalledWith([NoteEvents.UpdateTitle])
   })
 
   it('if the title was set to an empty string, then the original title renders', async () => {
@@ -57,7 +57,7 @@ describe('editor', () => {
     expect(getByRole('button', { name: 'Note title' })).toHaveTextContent(
       note.title
     )
-    expect(createEvent).not.toHaveBeenCalled()
+    expect(createEvent).not.toHaveBeenCalledWith([NoteEvents.UpdateTitle])
   })
 
   it('if the title was changed, then calls the update title event', async () => {

--- a/src-ui/renderer/reactive/editor/editor.ts
+++ b/src-ui/renderer/reactive/editor/editor.ts
@@ -369,8 +369,6 @@ class Editor {
         responsivenessConfig.forEach(processResponsiveConfig)
 
       showHideEllipsisButton()
-
-      // TODO: resize very long titles and the title input
     }
 
     // must debounce the resize handler by some amount or else e2e fails

--- a/src-ui/renderer/reactive/editor/editor.ts
+++ b/src-ui/renderer/reactive/editor/editor.ts
@@ -501,6 +501,12 @@ class Editor {
     input.focus()
   }
 
+  private getCursorPosition() {
+    if (!this.editor) return
+    const { from, to } = this.editor.state.selection
+    return { from, to }
+  }
+
   private instantiateTipTap(note: Note | null) {
     if (!this.editorContainer) return
     const editor = new TipTapEditor({
@@ -534,6 +540,10 @@ class Editor {
         Underline,
       ],
       content: note?.content ?? NO_NOTE_CONTENT,
+      onBlur: () => {
+        const position = this.getCursorPosition()
+        console.log('position', position)
+      },
       onUpdate: ({ transaction }) => {
         this.isDirty = transaction.docChanged
         const debounceSave = () => {
@@ -542,6 +552,8 @@ class Editor {
             createEvent(NoteEvents.Save, {
               shouldShowNotification: false,
             }).dispatch()
+            const position = this.getCursorPosition()
+            console.log('position', position)
           }, 300)
         }
         if (this.isDirty) debounceSave()

--- a/src-ui/renderer/reactive/status-bar/status-bar.css
+++ b/src-ui/renderer/reactive/status-bar/status-bar.css
@@ -65,7 +65,7 @@
   background-color: var(--button-hover-color);
 }
 
-@media (max-width: 580px) {
+@media (max-width: 640px) {
   .status-bar-hide-on-mobile {
     display: none !important;
   }

--- a/src-ui/use-local-storage/use-local-storage.spec.ts
+++ b/src-ui/use-local-storage/use-local-storage.spec.ts
@@ -4,8 +4,8 @@ import { useLocalStorage } from './use-local-storage'
 import type { DatabaseDetails, SidebarWidth } from './use-local-storage'
 
 vi.mock('logger')
-
 vi.mocked(logger.log).mockImplementation(vi.fn())
+
 const localStorageGetSpy = vi.spyOn(Storage.prototype, 'getItem')
 const localStorageSetSpy = vi.spyOn(Storage.prototype, 'setItem')
 
@@ -98,7 +98,20 @@ describe('use-local-storage', () => {
     expect(useLocalStorage.get('sidebar-width')).toEqual({ width: 200 })
   })
 
-  it.todo('if a note is not found, returns the default cursor position')
+  it('can set cursor position and always have the default returned', () => {
+    // disable the spies for this test
+    localStorageGetSpy.mockRestore()
+    localStorageSetSpy.mockRestore()
 
-  it.todo('if a note is found, returns the stored cursor position')
+    const original = useLocalStorage.get('cursor-position')
+    useLocalStorage.set('cursor-position', {
+      ...original,
+      'note-id': { from: 3, to: 3 },
+    })
+    const positions = useLocalStorage.get('cursor-position')
+    expect(positions).toEqual({
+      default: { from: 1, to: 1 },
+      'note-id': { from: 3, to: 3 },
+    })
+  })
 })

--- a/src-ui/use-local-storage/use-local-storage.spec.ts
+++ b/src-ui/use-local-storage/use-local-storage.spec.ts
@@ -97,4 +97,8 @@ describe('use-local-storage', () => {
     localStorageGetSpy.mockReturnValue(JSON.stringify({ width: 200 }))
     expect(useLocalStorage.get('sidebar-width')).toEqual({ width: 200 })
   })
+
+  it.todo('if a note is not found, returns the default cursor position')
+
+  it.todo('if a note is found, returns the stored cursor position')
 })

--- a/src-ui/use-local-storage/use-local-storage.ts
+++ b/src-ui/use-local-storage/use-local-storage.ts
@@ -1,5 +1,14 @@
 import { logger } from 'logger'
 
+type AllowedKeys = 'remote-db-details' | 'sidebar-width' | 'cursor-position'
+
+interface CursorPosition {
+  [key: string]: {
+    from: number
+    to: number
+  }
+}
+
 interface DatabaseDetails {
   [key: string]: string // needed for correct type indexing
   username: string
@@ -12,15 +21,15 @@ interface SidebarWidth {
   width: number
 }
 
-type AllowedKeys = 'remote-db-details' | 'sidebar-width'
-
 class UseLocalStorage {
   private validators = {
+    'cursor-position': this.validateCursorPosition,
     'remote-db-details': this.validateDetails,
     'sidebar-width': this.validateSidebarWidth,
   }
 
   private defaults: Record<AllowedKeys, unknown> = {
+    'cursor-position': { from: 1, to: 1 },
     'remote-db-details': {
       username: '',
       password: '',
@@ -37,9 +46,12 @@ class UseLocalStorage {
     return isValid ? parsed : this.defaults[key]
   }
 
-  public set(key: AllowedKeys, object: DatabaseDetails | SidebarWidth) {
+  public set(
+    key: AllowedKeys,
+    object: DatabaseDetails | SidebarWidth | CursorPosition
+  ) {
     const isValid = this.validators[key](
-      object as unknown as DatabaseDetails & SidebarWidth
+      object as unknown as DatabaseDetails & SidebarWidth & CursorPosition
     )
     isValid
       ? window.localStorage.setItem(key, JSON.stringify(object))
@@ -48,6 +60,14 @@ class UseLocalStorage {
           `Invalid ${key}. Attempted to set local storage with: ` +
             JSON.stringify(object)
         )
+  }
+
+  private validateCursorPosition(cursorPosition: CursorPosition): boolean {
+    return (
+      cursorPosition &&
+      typeof cursorPosition?.from === 'number' &&
+      typeof cursorPosition?.to === 'number'
+    )
   }
 
   private validateDetails(detail: DatabaseDetails): boolean {


### PR DESCRIPTION
**Overview**
- Save and restore cursor position in editor. I considered doing this in the database, but local storage is more flexible as it doesn't require changing the schema.
- Updated `useLocalStorage` to support saving cursor position and always loading a default
- Added mode for whether db url is `http` or `https` (revisit later when Tauri v2 is out)
