### PR TITLE
fix/mac-placeholder-code-sign

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,10 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "targets": "all"
+    "targets": "all",
+    "macOS": {
+      "signingIdentity": "-"
+    }
   },
   "productName": "notes",
   "mainBinaryName": "notes",
@@ -36,8 +39,5 @@
     "security": {
       "csp": null
     }
-  },
-  "macOS": {
-    "signingIdentity": "-"
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,5 +36,8 @@
     "security": {
       "csp": null
     }
+  },
+  "macOS": {
+    "signingIdentity": "-"
   }
 }


### PR DESCRIPTION
Attempting to run the `dmg` file generated by the github action failed. Adding a placeholder.